### PR TITLE
Improve decoding throughput

### DIFF
--- a/src/codec/buffer.go
+++ b/src/codec/buffer.go
@@ -16,12 +16,13 @@ import (
 type Buffer struct {
 	buf   []byte
 	index int
+	len   int
 }
 
 // NewBuffer creates a new buffer with the given slice of bytes as the
 // buffer's initial contents.
 func NewBuffer(buf []byte) *Buffer {
-	return &Buffer{buf: buf}
+	return &Buffer{buf: buf, index: 0, len: len(buf)}
 }
 
 // Reset resets this buffer back to empty. Any subsequent writes/encodes
@@ -29,6 +30,7 @@ func NewBuffer(buf []byte) *Buffer {
 func (cb *Buffer) Reset(buf []byte) {
 	cb.buf = buf
 	cb.index = 0
+	cb.len = len(buf)
 }
 
 // Bytes returns the slice of bytes remaining in the buffer. Note that
@@ -41,7 +43,7 @@ func (cb *Buffer) Bytes() []byte {
 
 // EOF returns true if there are no more bytes remaining to read.
 func (cb *Buffer) EOF() bool {
-	return cb.index >= len(cb.buf)
+	return cb.index >= cb.len
 }
 
 // Skip attempts to skip the given number of bytes in the input. If
@@ -53,7 +55,7 @@ func (cb *Buffer) Skip(count int) error {
 		return fmt.Errorf("proto: bad byte length %d", count)
 	}
 	newIndex := cb.index + count
-	if newIndex < cb.index || newIndex > len(cb.buf) {
+	if newIndex < cb.index || newIndex > cb.len {
 		return io.ErrUnexpectedEOF
 	}
 	cb.index = newIndex
@@ -62,7 +64,7 @@ func (cb *Buffer) Skip(count int) error {
 
 // Len returns the remaining number of bytes in the buffer.
 func (cb *Buffer) Len() int {
-	return len(cb.buf) - cb.index
+	return cb.len - cb.index
 }
 
 // Read implements the io.Reader interface. If there are no bytes
@@ -71,7 +73,7 @@ func (cb *Buffer) Len() int {
 // them into dest. It returns the number of bytes copied and a nil
 // error in this case.
 func (cb *Buffer) Read(dest []byte) (int, error) {
-	if cb.index == len(cb.buf) {
+	if cb.index == cb.len {
 		return 0, io.EOF
 	}
 	copied := copy(dest, cb.buf[cb.index:])

--- a/src/codec/decode.go
+++ b/src/codec/decode.go
@@ -53,7 +53,7 @@ func (cb *Buffer) DecodeVarint() (uint64, error) {
 		bit  = 1 << 7
 		mask = bit - 1
 	)
-	if cb.len >= 10 { // no bound checks
+	if cb.len >= 10 {
 		// i == 0
 		b := cb.buf[cb.index]
 		if b < bit {

--- a/tests/molecule_benchmark_test.go
+++ b/tests/molecule_benchmark_test.go
@@ -2,19 +2,18 @@ package moleculetest
 
 import (
 	"testing"
-	"time"
 
 	"github.com/richardartoul/molecule"
 	"github.com/richardartoul/molecule/src/codec"
-	"github.com/richardartoul/molecule/src/proto"
+	simple "github.com/richardartoul/molecule/src/proto"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/google/gofuzz"
+	fuzz "github.com/google/gofuzz"
 )
 
 func BenchmarkMolecule(b *testing.B) {
 	var (
-		seed   = time.Now().UnixNano()
+		seed   = int64(1623963202)
 		fuzzer = fuzz.NewWithSeed(seed)
 	)
 	// Limit slice size to prevent tests from taking too long.
@@ -31,6 +30,103 @@ func BenchmarkMolecule(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			err := proto.Unmarshal(marshaled, into)
 			noErr(err)
+		}
+	})
+
+	b.Run("unmarshal all", func(b *testing.B) {
+		msgBuffer := codec.NewBuffer(marshaled)
+		m := &simple.Simple{}
+		for i := 0; i < b.N; i++ {
+			msgBuffer.Reset(marshaled)
+			err := molecule.MessageEach(msgBuffer, func(fieldNum int32, value molecule.Value) (bool, error) {
+				var err error
+				switch fieldNum {
+				case 1:
+					m.Double, err = value.AsDouble()
+				case 2:
+					m.Float, err = value.AsFloat()
+				case 3:
+					m.Int32, err = value.AsInt32()
+				case 4:
+					m.Int64, err = value.AsInt64()
+				case 5:
+					m.Uint32, err = value.AsUint32()
+				case 6:
+					m.Uint64, err = value.AsUint64()
+				case 7:
+					m.Sint32, err = value.AsSint32()
+				case 8:
+					m.Sint64, err = value.AsSint64()
+				case 9:
+					m.Fixed32, err = value.AsFixed32()
+				case 10:
+					m.Fixed64, err = value.AsFixed64()
+				case 11:
+					m.Sfixed32, err = value.AsSFixed32()
+				case 12:
+					m.Sfixed64, err = value.AsSFixed64()
+				case 13:
+					m.Bool, err = value.AsBool()
+				case 14:
+					m.String_, err = value.AsStringUnsafe()
+				case 15:
+					m.Bytes, err = value.AsBytesUnsafe()
+				case 16:
+
+				}
+
+				return err == nil, err
+			})
+			noErr(err)
+		}
+	})
+
+	b.Run("unmarshal loop", func(b *testing.B) {
+		msgBuffer := codec.NewBuffer(marshaled)
+		m := &simple.Simple{}
+		for i := 0; i < b.N; i++ {
+			msgBuffer.Reset(marshaled)
+			value := molecule.Value{}
+			for !msgBuffer.EOF() {
+				fieldNum, err := molecule.Next(msgBuffer, &value)
+				noErr(err)
+
+				switch fieldNum {
+				case 1:
+					m.Double, err = value.AsDouble()
+				case 2:
+					m.Float, err = value.AsFloat()
+				case 3:
+					m.Int32, err = value.AsInt32()
+				case 4:
+					m.Int64, err = value.AsInt64()
+				case 5:
+					m.Uint32, err = value.AsUint32()
+				case 6:
+					m.Uint64, err = value.AsUint64()
+				case 7:
+					m.Sint32, err = value.AsSint32()
+				case 8:
+					m.Sint64, err = value.AsSint64()
+				case 9:
+					m.Fixed32, err = value.AsFixed32()
+				case 10:
+					m.Fixed64, err = value.AsFixed64()
+				case 11:
+					m.Sfixed32, err = value.AsSFixed32()
+				case 12:
+					m.Sfixed64, err = value.AsSFixed64()
+				case 13:
+					m.Bool, err = value.AsBool()
+				case 14:
+					m.String_, err = value.AsStringUnsafe()
+				case 15:
+					m.Bytes, err = value.AsBytesUnsafe()
+				case 16:
+
+				}
+				noErr(err)
+			}
 		}
 	})
 


### PR DESCRIPTION
This commit combines a few changes that improve the decoding throughput.

```
name                                         old time/op  new time/op  delta
Molecule/standard_unmarshal-8                1.28µs ± 8%  1.32µs ± 4%   +2.64%  (p=0.000 n=23+23)
Molecule/unmarshal_all-8                      330ns ± 2%   211ns ± 6%  -36.09%  (p=0.000 n=25+21)
Molecule/unmarshal_loop-8                     322ns ± 1%   169ns ± 3%  -47.62%  (p=0.000 n=22+22)
Molecule/unmarshal_single_with_molecule-8     257ns ± 2%   165ns ± 2%  -35.72%  (p=0.000 n=21+21)
Molecule/unmarshal_multiple_with_molecule-8  1.49µs ± 7%  0.99µs ± 4%  -33.36%  (p=0.000 n=25+24)
```

I attempted to switch one of our apps to use molecule instead of the gogo generated code but I found that the CPU usage of using molecule significantly worse.

The most obvious thing in the profiler was `DecodeVarint` so I initially focused my efforts there.  I originally replaced `DecodeVarint` with the body of `decodeVarintSlow` as this allowed the function to be inlined.  However, the implementation from https://github.com/dennwc/varint was faster still, even accounting for the fact that it is too complex to be inlined.

The improvements here mainly focus on either inlining methods directly or modifying them so that they are eligible to be inlined.  My intuition is that the call-site overhead was actually contributing to the the CPU usage so inlining where possible seemed to help.

I also added a `Next()` method that allows a different method of iterating over the values, you can see in the benchmark that this is significantly faster than using `MessageEach`, again I think this is due to call-site overhead / stack management.  I'm not sure how you feel about having competing APIs like this but the improvement to me seems worthwhile.

Open to suggestions on how to improve this further.