### PR TITLE
DecodeVarint: Fix panic on truncated input; Add tests

### DIFF
--- a/src/codec/decode.go
+++ b/src/codec/decode.go
@@ -45,7 +45,7 @@ func init() {
 //
 // This implementation is inlined from https://github.com/dennwc/varint to avoid the call-site overhead
 func (cb *Buffer) DecodeVarint() (uint64, error) {
-	if cb.len == 0 {
+	if cb.Len() == 0 {
 		return 0, io.ErrUnexpectedEOF
 	}
 	const (
@@ -53,7 +53,7 @@ func (cb *Buffer) DecodeVarint() (uint64, error) {
 		bit  = 1 << 7
 		mask = bit - 1
 	)
-	if cb.len >= 10 {
+	if cb.Len() >= 10 {
 		// i == 0
 		b := cb.buf[cb.index]
 		if b < bit {
@@ -143,7 +143,7 @@ func (cb *Buffer) DecodeVarint() (uint64, error) {
 			}
 			cb.index += 10
 			return x | uint64(b)<<s, nil
-		} else if cb.len == 10 {
+		} else if cb.Len() == 10 {
 			return 0, io.ErrUnexpectedEOF
 		}
 		for _, b := range cb.buf[cb.index+10:] {
@@ -159,7 +159,7 @@ func (cb *Buffer) DecodeVarint() (uint64, error) {
 	if b < bit {
 		cb.index++
 		return uint64(b), nil
-	} else if cb.len == 1 {
+	} else if cb.Len() == 1 {
 		return 0, io.ErrUnexpectedEOF
 	}
 	x := uint64(b & mask)
@@ -170,7 +170,7 @@ func (cb *Buffer) DecodeVarint() (uint64, error) {
 	if b < bit {
 		cb.index += 2
 		return x | uint64(b)<<s, nil
-	} else if cb.len == 2 {
+	} else if cb.Len() == 2 {
 		return 0, io.ErrUnexpectedEOF
 	}
 	x |= uint64(b&mask) << s
@@ -181,7 +181,7 @@ func (cb *Buffer) DecodeVarint() (uint64, error) {
 	if b < bit {
 		cb.index += 3
 		return x | uint64(b)<<s, nil
-	} else if cb.len == 3 {
+	} else if cb.Len() == 3 {
 		return 0, io.ErrUnexpectedEOF
 	}
 	x |= uint64(b&mask) << s
@@ -192,7 +192,7 @@ func (cb *Buffer) DecodeVarint() (uint64, error) {
 	if b < bit {
 		cb.index += 4
 		return x | uint64(b)<<s, nil
-	} else if cb.len == 4 {
+	} else if cb.Len() == 4 {
 		return 0, io.ErrUnexpectedEOF
 	}
 	x |= uint64(b&mask) << s
@@ -203,7 +203,7 @@ func (cb *Buffer) DecodeVarint() (uint64, error) {
 	if b < bit {
 		cb.index += 5
 		return x | uint64(b)<<s, nil
-	} else if cb.len == 5 {
+	} else if cb.Len() == 5 {
 		return 0, io.ErrUnexpectedEOF
 	}
 	x |= uint64(b&mask) << s
@@ -214,7 +214,7 @@ func (cb *Buffer) DecodeVarint() (uint64, error) {
 	if b < bit {
 		cb.index += 6
 		return x | uint64(b)<<s, nil
-	} else if cb.len == 6 {
+	} else if cb.Len() == 6 {
 		return 0, io.ErrUnexpectedEOF
 	}
 	x |= uint64(b&mask) << s
@@ -225,7 +225,7 @@ func (cb *Buffer) DecodeVarint() (uint64, error) {
 	if b < bit {
 		cb.index += 7
 		return x | uint64(b)<<s, nil
-	} else if cb.len == 7 {
+	} else if cb.Len() == 7 {
 		return 0, io.ErrUnexpectedEOF
 	}
 	x |= uint64(b&mask) << s
@@ -236,7 +236,7 @@ func (cb *Buffer) DecodeVarint() (uint64, error) {
 	if b < bit {
 		cb.index += 8
 		return x | uint64(b)<<s, nil
-	} else if cb.len == 8 {
+	} else if cb.Len() == 8 {
 		return 0, io.ErrUnexpectedEOF
 	}
 	x |= uint64(b&mask) << s
@@ -247,7 +247,7 @@ func (cb *Buffer) DecodeVarint() (uint64, error) {
 	if b < bit {
 		cb.index += 9
 		return x | uint64(b)<<s, nil
-	} else if cb.len == 9 {
+	} else if cb.Len() == 9 {
 		return 0, io.ErrUnexpectedEOF
 	}
 	x |= uint64(b&mask) << s
@@ -261,7 +261,7 @@ func (cb *Buffer) DecodeVarint() (uint64, error) {
 		}
 		cb.index += 10
 		return x | uint64(b)<<s, nil
-	} else if cb.len == 10 {
+	} else if cb.Len() == 10 {
 		return 0, io.ErrUnexpectedEOF
 	}
 	for _, b := range cb.buf[cb.index+10:] {

--- a/tests/molecule_test.go
+++ b/tests/molecule_test.go
@@ -126,3 +126,70 @@ func TestMoleculeSimple(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+type FuzzSplitBytes struct {
+	bytes    []byte
+	selected int
+}
+
+func (f *FuzzSplitBytes) Fuzz(c fuzz.Continue) {
+	f.selected = c.Intn(len(f.bytes))
+}
+
+func fuzzSplitBytes(fuzzer *fuzz.Fuzzer, bytes []byte) []byte {
+	splitter := &FuzzSplitBytes{bytes, 0}
+	fuzzer.Fuzz(splitter)
+	return bytes[:splitter.selected]
+}
+
+func TestMoleculeTruncatedShouldNotPanic(t *testing.T) {
+	var (
+		seed      = time.Now().UnixNano()
+		fuzzer    = fuzz.NewWithSeed(seed)
+		numFuzzes = 100000
+	)
+	defer func() {
+		// Log the seed to make debugging failures easier.
+		t.Logf("Running test with seed: %d", seed)
+	}()
+	// Limit slice size to prevent tests from taking too long.
+	fuzzer.NumElements(0, 100)
+
+	for i := 0; i < numFuzzes; i++ {
+		m := &simple.Simple{}
+		fuzzer.Fuzz(&m)
+		if m == nil {
+			continue
+		}
+
+		marshaled, err := proto.Marshal(m)
+		require.NoError(t, err)
+		require.NotEmpty(t, marshaled)
+
+		// split the buffer: iterating over it should not panic
+		// there was a bug in DecodeVarint that caused panics
+		splitMarshaled := fuzzSplitBytes(fuzzer, marshaled)
+		buffer := codec.NewBuffer(splitMarshaled)
+		err = molecule.MessageEach(buffer, func(fieldNum int32, value molecule.Value) (bool, error) {
+			return true, nil
+		})
+		// sometimes this split will actually generate a "correct" truncation: err == nil is okay
+		if err != nil {
+			require.Error(t, err, "unexpected EOF", "wtf %#v %#v", string(splitMarshaled), m)
+		}
+	}
+}
+
+func TestMoleculeTruncated(t *testing.T) {
+	payload := &simple.Simple{Int64: 42}
+	serialized, err := proto.Marshal(payload)
+	require.NoError(t, err)
+
+	// truncate the payload at the 1 byte mark: parsing should return an error, not panic
+	// this is a simplified case of a bug found by the TestMoleculeTruncatedShouldNotPanic fuzzer
+	buffer := codec.NewBuffer(serialized[:1])
+	err = molecule.MessageEach(buffer, func(fieldNum int32, value molecule.Value) (bool, error) {
+		return true, nil
+	})
+	require.Error(t, err, "unexpected EOF")
+}


### PR DESCRIPTION
Replace references to cb.len with cb.Len() to ensure we are checking
the difference from cb.len - cb.index. When some values have already
been parsed, DecodeVarint will be called with cb.index > 0, which
means the existing bounds checks were wrong

Commit 775411c3fa added faster decoding of varints, but omitted some
of the bounds checks. This means that using this library to parse
truncated inputs now panics, instead of returning an error.

Add a fuzz test to ensure this continues to work. Add a deterministic
unit test extracted from the fuzz test as an easy to understand
example.