### PR TITLE
Set a cap on slices returned from AsBytesUnsafe

### DIFF
--- a/src/codec/decode.go
+++ b/src/codec/decode.go
@@ -345,7 +345,9 @@ func (cb *Buffer) DecodeRawBytes(alloc bool) (buf []byte, err error) {
 	}
 
 	if !alloc {
-		buf = cb.buf[cb.index:end]
+		// We set a cap on the returned slice equal to the length of the buffer so that it is not possible
+		// to read past the end of this slice
+		buf = cb.buf[cb.index:end:end]
 		cb.index = end
 		return
 	}

--- a/tests/molecule_test.go
+++ b/tests/molecule_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/richardartoul/molecule"
 	"github.com/richardartoul/molecule/src/codec"
-	"github.com/richardartoul/molecule/src/proto"
+	simple "github.com/richardartoul/molecule/src/proto"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/google/gofuzz"
+	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/require"
 )
 
@@ -101,6 +101,7 @@ func TestMoleculeSimple(t *testing.T) {
 				v, err := value.AsBytesUnsafe()
 				require.NoError(t, err)
 				require.Equal(t, m.Bytes, v)
+				require.Equal(t, len(v), cap(v))
 			case 16:
 				packedArr, err := value.AsBytesUnsafe()
 				require.NoError(t, err)


### PR DESCRIPTION
This will prevent callers from reading past the end of the slice returned from `AsBytesUnsafe`.

Benchmark below shows no change (count=10)

```
name                                         old time/op    new time/op    delta
Molecule/standard_unmarshal-8                  1.45µs ± 1%    1.44µs ± 1%  -0.68%  (p=0.025 n=9+8)
Molecule/unmarshal_all-8                        169ns ± 1%     170ns ± 3%    ~     (p=0.642 n=10+10)
Molecule/unmarshal_loop-8                       154ns ± 1%     154ns ± 2%    ~     (p=0.561 n=9+10)
Molecule/unmarshal_single_with_molecule-8       124ns ± 1%     124ns ± 2%    ~     (p=0.725 n=10+10)
Molecule/unmarshal_multiple_with_molecule-8     746ns ± 1%     748ns ± 1%    ~     (p=0.565 n=10+10)
Simple-8                                        270ns ± 2%     268ns ± 0%    ~     (p=0.617 n=10+8)
Packing-8                                       179µs ±10%     167µs ±12%    ~     (p=0.156 n=10+9)

name                                         old alloc/op   new alloc/op   delta
Simple-8                                        1.00B ± 0%     1.00B ± 0%    ~     (all equal)
Packing-8                                        835B ± 5%      832B ± 2%    ~     (p=0.880 n=10+8)

name                                         old allocs/op  new allocs/op  delta
Simple-8                                         1.00 ± 0%      1.00 ± 0%    ~     (all equal)
Packing-8                                        0.00           0.00         ~     (all equal)
```