### PR TITLE
Implement ProtoStream.Write()

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -435,6 +435,11 @@ func (ps *ProtoStream) Embedded(fieldNumber int, inner func(*ProtoStream) error)
 	return ps.writeAll(ps.childBuffer.Bytes())
 }
 
+// Write writes directly to the underlaying writer.
+func (ps *ProtoStream) Write(p []byte) (int, error) {
+	return ps.outputWriter.Write(p)
+}
+
 // writeScratch flushes the scratch buffer to output.
 func (ps *ProtoStream) writeScratch() error {
 	return ps.writeAll(ps.scratchBuffer)

--- a/stream.go
+++ b/stream.go
@@ -435,9 +435,10 @@ func (ps *ProtoStream) Embedded(fieldNumber int, inner func(*ProtoStream) error)
 	return ps.writeAll(ps.childBuffer.Bytes())
 }
 
-// Write writes directly to the underlaying writer.
-func (ps *ProtoStream) Write(p []byte) (int, error) {
-	return ps.outputWriter.Write(p)
+// Write writes raw []byte to the underlying writer. It is the callers
+// responsibility to make sure this wont yield a corrupt protobuf stream.
+func (ps *ProtoStream) Write(raw []byte) (int, error) {
+	return ps.outputWriter.Write(raw)
 }
 
 // writeScratch flushes the scratch buffer to output.

--- a/tests/stream_test.go
+++ b/tests/stream_test.go
@@ -86,6 +86,13 @@ func TestSimpleEncoding(t *testing.T) {
 	require.NoError(t, ps.String(fieldString, "reset"))
 	require.NoError(t, proto.Unmarshal(output2.Bytes(), &res))
 	assert.Equal(t, "reset", res.String_)
+
+	// test Write
+	output3 := bytes.NewBuffer([]byte{})
+	ps.Reset(output3)
+	n, err := ps.Write([]byte{1, 2, 3, 4})
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
 }
 
 // Test that the zero values for each field do not result in any encoded data.


### PR DESCRIPTION
There are two use case:

1) Writing pre-encoded buffers into the stream.
2) Writing string fields that can sometimes be `""` without `if/else`

A real-world example for the second use case is writing entries into pprof's Profile.string_table [1] where the first entry must be an empty string:

```go
func writeStringTable(ps *molecule.ProtoStream, str string) {
  ps.Embedded(6, func(ps *molecule.ProtoStream) error {
    _, err := ps.Write([]byte(str))
    return err
  })
}

writeStringTable(ps, "") // must be written (!)
writeStringTable(ps, "foo")
```

Without this patch one would you have to write something like this:

```go
func writeStringTable(ps *molecule.ProtoStream, str string) {
  if len(str) == 0 {
    ps.Embedded(6, func(ps *molecule.ProtoStream) error {
      return nil
    })
  } else {
    ps.String(6, str)
  }
}

writeStringTable(ps, "") // must be written (!)
writeStringTable(ps, "foo")
```

[1] https://github.com/google/pprof/blob/d260c55eee4ceee9be31ddc2517f54a0d92b85ec/proto/profile.proto#L65-L67