### PR TITLE
doc.go: Move package after package comment

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,3 @@
-package molecule
-
 // Package molecule is a Go library for parsing and encoding protobufs in an
 // efficient and zero-allocation manner, progressively consuming or creating
 // the encoded bytes in a streaming fashion instead of (un)marhsaling full
@@ -43,3 +41,4 @@ package molecule
 // examples for details.
 //
 // Note that most methods will do nothing when given their zero value.
+package molecule


### PR DESCRIPTION
This detailed package comment is not being recognized by Go as a package comment because it needs to come immediately before the package statement. This should make this comment appear on pkg.go.dev. Fixes staticcheck warnings:

doc.go:1:1: at least one file in a package should have a package comment (ST1000)